### PR TITLE
fix: check effective uid instead of username for root

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -239,7 +239,7 @@ func printUsage() {
 
 func validatePrerequisites() {
 	// Validate current user
-	err := utils.CheckCurrentUser("root")
+	err := utils.CheckRoot()
 	if err != nil {
 		log.Printf("WARNING: current user is not root: %s", err.Error())
 		log.Printf("WARNING: exporter will continue running but scrapes will fail")

--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 	"time"
 
@@ -61,14 +61,12 @@ func ExecuteJSONCommand(cmd string, args ...string) (gjson.Result, error) {
 	return ret, nil
 }
 
-func CheckCurrentUser(wantedUser string) error {
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("error checking current user: %w", err)
-	}
-
-	if currentUser.Username != wantedUser {
-		return fmt.Errorf("current user %s is not wanted user %s", currentUser.Username, wantedUser)
+// CheckRoot verifies the process is running with root privileges by
+// checking the effective user ID. This is more reliable than comparing
+// the username, which misses uid-0 accounts not literally named "root".
+func CheckRoot() error {
+	if euid := os.Geteuid(); euid != 0 {
+		return fmt.Errorf("effective uid is %d, not 0 (root)", euid)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
The root-privilege check compared `currentUser.Username` against the literal string `"root"`, which misses uid-0 accounts that are not named `root`. Switched to an effective-uid check.

## Changes
- Replace `utils.CheckCurrentUser(wantedUser string)` with `utils.CheckRoot()`, which returns an error unless `os.Geteuid() == 0`.
- Update the caller in `cmd/main.go`.
- Drop the now-unused `os/user` import.

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅