### PR TITLE
cleanup: minor fixes (flag init, HTTP timeouts)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -117,34 +117,26 @@ func isValidationValid() bool {
 }
 
 func initCollectorFlags() {
-	// Register flags for each collector
+	// collector is a *Collector, so assigning collector.enabled mutates the
+	// entry stored in the map directly.
 	for name, collector := range collectors {
-		flagName := "collector." + name
-		noFlagName := "no-collector." + name
-
 		defaultValue := collector.defaultState
 
-		// --collector.X flag to enable
-		enableFlag := flag.Bool(
-			flagName,
+		// --collector.X enables the collector.
+		collector.enabled = flag.Bool(
+			"collector."+name,
 			defaultValue,
 			fmt.Sprintf("Enable the %s collector (default: %t)", collector.description, defaultValue),
 		)
 
-		// --no-collector.X flag to disable
-		disableFlag := flag.Bool(
-			noFlagName,
+		// --no-collector.X disables it. We only need the flag registered so it
+		// parses and flag.Visit can detect it in resolveCollectorStates; its
+		// value is never read directly.
+		flag.Bool(
+			"no-collector."+name,
 			false,
 			fmt.Sprintf("Disable the %s collector", collector.description),
 		)
-
-		collector.enabled = enableFlag
-
-		// Store both flags so we can resolve them later
-		collectors[name] = collector
-
-		// The disable flag is handled in resolveCollectorStates
-		_ = disableFlag
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -346,6 +346,12 @@ func main() {
 	server := &http.Server{
 		Addr:              *listenAddress,
 		ReadHeaderTimeout: 3 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		// A scrape shells out to nvme per device (each bounded by the 30s
+		// command timeout), so WriteTimeout is kept well above a normal
+		// scrape to avoid truncating responses on hosts with many devices.
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
## Summary
Two small, independent cleanups, one per commit.

## Commits
1. **refactor: simplify initCollectorFlags** — remove the no-op `collectors[name] = collector` reassignment (the value is already a pointer) and the discarded `disableFlag` variable. The `--no-collector.X` flag is still registered for parsing and `flag.Visit` detection.
2. **fix: set read/write/idle timeouts on HTTP server** — previously only `ReadHeaderTimeout` was set. Add `ReadTimeout` and `IdleTimeout`, plus a `WriteTimeout` sized generously above a normal multi-device scrape (each `nvme` call is bounded by the existing 30s command timeout) to avoid truncating responses.

## Note
A third planned cleanup (replacing the `map[string]interface{}` in `flattenNewStructure` with a typed struct) was dropped: it triggers a lint conflict — `musttag` requires `json` tags, `tagliatelle` requires camelCase tags, but the keys must stay PascalCase to match what the collectors read via gjson. The existing map approach avoids all of this.

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅