### PR TITLE
docs: cache the downloads badge to reduce shields flakiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![build](https://github.com/E4-Computer-Engineering/nvme-exporter/actions/workflows/build.yml/badge.svg)](https://github.com/E4-Computer-Engineering/nvme-exporter/actions/workflows/build.yml)
 ![Latest GitHub release](https://img.shields.io/github/release/E4-Computer-Engineering/nvme-exporter.svg)
 [![GitHub license](https://img.shields.io/github/license/E4-Computer-Engineering/nvme-exporter)](https://github.com/E4-Computer-Engineering/nvme-exporter/blob/master/LICENSE)
-![GitHub all releases](https://img.shields.io/github/downloads/E4-Computer-Engineering/nvme-exporter/total)
+![GitHub all releases](https://img.shields.io/github/downloads/E4-Computer-Engineering/nvme-exporter/total?cacheSeconds=86400)
 
 Prometheus exporter for NVMe SMART log and OCP SMART log metrics, inspired by [fritchie nvme exporter](https://github.com/fritchie/nvme_exporter) and following [Prometheus node_exporter](https://github.com/prometheus/node_exporter) design patterns.
 


### PR DESCRIPTION
## Summary
The all-releases downloads badge (`…/downloads/<owner>/<repo>/total`) intermittently renders `downloads: invalid`. Cause: shields.io fetches **every** release via the **unauthenticated** GitHub API and periodically hits rate limits; GitHub's Camo proxy then caches the failed render until the next refresh.

## Change
Append `?cacheSeconds=86400` to the badge URL so shields serves the cached good value for ~a day and re-fetches far less often — shrinking the window for a transient "invalid".

## Notes
This is a mitigation, not a cure (a refresh that lands during a rate-limit can still cache an "invalid"). The bulletproof alternative is switching to `/latest/total` (one API call), at the cost of showing latest-release downloads instead of all-time.

The repo is public and the unauthenticated releases API returns 200, so nothing repo-side is broken.